### PR TITLE
include unistd.h for getopt

### DIFF
--- a/src/exfiltrate.cc
+++ b/src/exfiltrate.cc
@@ -15,6 +15,7 @@
  */
 #include<string>
 #include<iostream>
+#include<unistd.h>
 
 #include"common.h"
 #include"internal.h"


### PR DESCRIPTION
This fixes a compilation issue on my machine:

```
x200 ~/simple-tpm-pk11 master $ make
make  all-recursive
make[1]: Entering directory `/home/michael/simple-tpm-pk11'
Making all in doc
make[2]: Entering directory `/home/michael/simple-tpm-pk11/doc'
make[2]: Nothing to be done for `all'.
make[2]: Leaving directory `/home/michael/simple-tpm-pk11/doc'
make[2]: Entering directory `/home/michael/simple-tpm-pk11'
depbase=`echo src/exfiltrate.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
    g++ -DHAVE_CONFIG_H -I.     -g -O2 -std=gnu++0x -Wall -MT src/exfiltrate.o -MD -MP -MF $depbase.Tpo -c -o src/exfiltrate.o src/exfiltrate.cc &&\
    mv -f $depbase.Tpo $depbase.Po
src/exfiltrate.cc: In function ‘int wrapped_main(int, char**)’:
src/exfiltrate.cc:50:49: error: ‘getopt’ was not declared in this scope
/**
   while (EOF != (c = getopt(argc, argv, "hk:Ops"))) {
                                                 ^
src/exfiltrate.cc:55:17: error: ‘optarg’ was not declared in this scope
       keyfile = optarg;
                 ^
make[2]: *** [src/exfiltrate.o] Error 1
make[2]: Leaving directory `/home/michael/simple-tpm-pk11'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/home/michael/simple-tpm-pk11'
make: *** [all] Error 2

```
