### PR TITLE
Replace the obsolete AC_PROG_LIBTOOL with LT_INIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ AC_SUBST([AM_LDFLAGS])
 # Library stuff.
 AC_ENABLE_SHARED
 AC_DISABLE_STATIC
-AC_PROG_LIBTOOL(libtool)
+LT_INIT(libtool)
 
 CXXFLAGS="$CXXFLAGS -std=gnu++0x -Wall"
 


### PR DESCRIPTION
More information:
https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>