### PR TITLE
Use the system precompiled copy of gtest if wanted

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,6 +76,13 @@ src/tspiwrap.cc \
 src/common.cc
 libsimple_tpm_pk11_la_LDFLAGS=-version-info 0:0:0
 
+if WITH_PRECOMPILED_GTEST
+common_test_LDADD+=-lgtest -lgtest_main
+pk11_test_LDADD+=-lgtest -lgtest_main
+stpm_keygen_test_LDADD+=-lgtest -lgtest_main
+stpm_sign_test_LDADD+=-lgtest -lgtest_main
+endif
+
 check-tpm:
 	./testscripts/all.sh
 

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,19 @@ AC_CHECK_HEADERS([opencryptoki/pkcs11.h], [], [
     [exit 1]
 ])
 
+AC_ARG_WITH(precompiled-gtest,
+  [ --with-precompiled-gtest   Use a system-provided precompiled version of gtest],
+  [case "${withval}" in
+     yes | no ) WITH_PRECOMPILED_GTEST="${withval}" ;;
+     *) AC_MSG_ERROR(bad value ${withval} for --with-precompiled-gtest) ;;
+   esac],
+  [WITH_PRECOMPILED_GTEST="no"]
+)
+AM_CONDITIONAL([WITH_PRECOMPILED_GTEST], [test "x$WITH_PRECOMPILED_GTEST" = "xyes"])
+AS_IF([test "x$WITH_PRECOMPILED_GTEST" = "xyes"], [
+    AC_DEFINE([PRECOMPILED_GTEST], [], ["build using precompiled gtest library"])
+])
+
 AC_PROG_CXX
 AC_PROG_INSTALL
 AC_SUBST([AM_CXXFLAGS])

--- a/src/libgtest.cc
+++ b/src/libgtest.cc
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 #include<string>
+#include<config.h>
 
+#ifndef PRECOMPILED_GTEST
 #include"/usr/src/gtest/src/gtest_main.cc"
 #include"/usr/src/gtest/src/gtest-all.cc"
+#endif
 
 std::string argv0base = "test-binary";


### PR DESCRIPTION
Instead of using the direct gtest source code, this makes
the testsuite use the precompiled version of gtest.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>