### PR TITLE
Clarify confusing reference to key identification blob as "private key".

### DIFF
--- a/doc/stpm-keygen.1
+++ b/doc/stpm-keygen.1
@@ -7,7 +7,7 @@ stpm\-keygen \- Generate key pair for use with simple\-tpm\-pk11
 .PP 
 .SH "DESCRIPTION"
 \fIstpm\-keygen\fP generates a 2048 RSA key inside the TPM chip, and saves
-the public key and the SRK\-encrypted private key (the \(dq\&blob\(dq\&) in the
+the public key and the SRK\-encrypted key blob in the
 \fIoutput file\fP\&.
 .PP 
 .SH "OPTIONS"

--- a/doc/stpm-keygen.1.yodl
+++ b/doc/stpm-keygen.1.yodl
@@ -6,7 +6,7 @@ manpagesynopsis()
 
 manpagedescription()
     em(stpm-keygen) generates a 2048 RSA key inside the TPM chip, and saves
-    the public key and the SRK-encrypted private key (the "blob") in the
+    the public key and the SRK-encrypted key blob in the
     em(output file).
 
 manpageoptions()


### PR DESCRIPTION
Hi,

I played around with my TPM using simple tpm-pk11, and I got quite confused by the mention of a "private key" being stored in "~/.simple-tpm-pk11/my.key" (what would be the point of using a TPM if the non-migratable private key is exported at generation time?).

After checking that TSS_TSPATTRIB_KEYBLOB_PRIVATE_KEY is indeed *not* used in stpm-keygen, I thought I would avoid headache for my peers through this patch :)

AFAICT the key blob is some kind of key identification but I didn't write that clearly since I couldn't find any official reference/definition about it (TrouSerS didn't help).