### PR TITLE
fix debug_log length

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -283,7 +283,7 @@ xsprintf(const char* fmt, ...) {
   vsnprintf(&buf[0], s, fmt, va2);
   va_end(va2);
 
-  return std::string(buf.begin(), buf.end());
+  return std::string(buf.begin(), buf.end()-1);
 }
 
 bool

--- a/src/session.cc
+++ b/src/session.cc
@@ -160,7 +160,7 @@ Config::debug_log(const char* fmt, ...) {
   va_end(va2);
 
   if (debug_) {
-    stpm::do_log(logfile_.get(), stpm::xctime() + " DEBUG " + std::string(buf.begin(), buf.end()));
+    stpm::do_log(logfile_.get(), stpm::xctime() + " DEBUG " + std::string(buf.begin(), buf.end()-1));
   }
 }
 


### PR DESCRIPTION
Size of the buf is formatted args plus one for \0. So actual string should be only up to end -1. You can see this when you enable debug logging and look it. There is \0 at the end of debug entries.