### PR TITLE
Typo in stpm-sign.1 doc

### DIFF
--- a/doc/stpm-sign.1
+++ b/doc/stpm-sign.1
@@ -18,7 +18,7 @@ Show usage info\&.
 .IP "\-f \fIinput file\fP"
 File containing data to be signed\&.
 .IP "\-k"
-Key to sign with\&. The key is generated with \fIstpm\-keysign\fP\&.
+Key to sign with\&. The key is generated with \fIstpm\-keygen\fP\&.
 .IP "\-s"
 Ask for the SRK password interactively\&. By default the
 \(dq\&Well Known Secret\(dq\& (20 nulls) is used\&. The SRK password is an


### PR DESCRIPTION
The manpage for stpm-sign references using `stpm-keysign` instead of `stpm-keygen` to generate keys.