### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: cpp
 compiler:
   - clang


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf on IBM. The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/simple-tpm-pk11/builds/208656471 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!