### PR TITLE
Various bug fixes

### DIFF
--- a/src/pk11.cc
+++ b/src/pk11.cc
@@ -90,6 +90,14 @@ log_debug(const std::string& msg)
   }
 }
 
+// string must be padded with space (0x20) and must not be null terminated
+static void
+write_pk11_str(void* dest, char* src, size_t src_size, size_t max_size)
+{
+  memset((char*)dest, 0x20, max_size);
+  memcpy((char*)dest, src, src_size > max_size ? max_size : src_size);
+}
+
 Config
 get_config()
 {
@@ -225,10 +233,14 @@ C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 {
   return wrap_exceptions(__func__, [&]{
       // TODO: fill these out from token.
-      strcpy((char*)pInfo->label, "Simple-TPM-PK11 token");
-      strcpy((char*)pInfo->manufacturerID, "manuf id");
-      strcpy((char*)pInfo->model, "model");
-      strcpy((char*)pInfo->serialNumber, "serial");
+      char label[] = "Simple-TPM-PK11 token";
+      char manuf_id[] = "manuf id";
+      char model[] = "model";
+      char serial[] = "serial";
+      write_pk11_str(pInfo->label, label, strlen(label), 32);
+      write_pk11_str(pInfo->manufacturerID, manuf_id, strlen(manuf_id), 32);
+      write_pk11_str(pInfo->model, model, strlen(model), 16);
+      write_pk11_str(pInfo->serialNumber, serial, strlen(serial), 16);
 
       // TODO: Add CKF_RNG.
       pInfo->flags = CKF_TOKEN_INITIALIZED;

--- a/src/pk11.cc
+++ b/src/pk11.cc
@@ -50,6 +50,12 @@ const std::string config_dir = ".simple-tpm-pk11";
 const char* env_debug = "SIMPLE_TPM_PK11_DEBUG";
 const char* env_config = "SIMPLE_TPM_PK11_CONFIG";
 const CK_SLOT_ID tpm_slot_id = 0x1234;
+const char library_description[] = "simple-tpm-pk11 library"; // 32
+const char manufacturer_id[] = "simple-tpm-pk11 manufacturer"; // 32
+const char slot_description[] = "Simple-TPM-PK11 slot"; // 64
+const char token_label[] = "Simple-TPM-PK11 token"; // 32
+const char token_model[] = "model"; // 16
+const char token_serial[] = "serial"; // 16
 
 // TODO: allocate and free sessions properly.
 std::vector<Session> sessions;
@@ -92,10 +98,10 @@ log_debug(const std::string& msg)
 
 // string must be padded with space (0x20) and must not be null terminated
 static void
-write_pk11_str(void* dest, char* src, size_t src_size, size_t max_size)
+write_pk11_str(void* dest, const char* src, size_t src_size, size_t max_size)
 {
   memset((char*)dest, 0x20, max_size);
-  memcpy((char*)dest, src, src_size > max_size ? max_size : src_size);
+  memcpy((char*)dest, src, std::min(src_size, max_size));
 }
 
 Config
@@ -146,8 +152,8 @@ C_GetInfo(CK_INFO_PTR pInfo)
       pInfo->cryptokiVersion.major = 0;
       pInfo->cryptokiVersion.minor = 1;
       // TODO: flags
-      strcpy((char*)pInfo->manufacturerID, "simple-tpm-pk11 manufacturer");
-      strcpy((char*)pInfo->libraryDescription, "simple-tpm-pk11 library");
+      write_pk11_str(pInfo->libraryDescription, library_description, strlen(library_description), 32);
+      write_pk11_str(pInfo->manufacturerID, manufacturer_id, strlen(manufacturer_id), 32);
 
       // TODO: take these version numbers from somewhere canonical.
       pInfo->libraryVersion.major = 0;
@@ -218,8 +224,8 @@ C_GetSlotInfo(CK_SLOT_ID slotID, CK_SLOT_INFO_PTR pInfo)
 {
   return wrap_exceptions(__func__, [&]{
       // TODO: fill these out from slot.
-      strcpy((char*)pInfo->slotDescription, "Simple-TPM-PK11 slot");
-      strcpy((char*)pInfo->manufacturerID, "manuf id");
+      write_pk11_str(pInfo->slotDescription, slot_description, strlen(slot_description), 64);
+      write_pk11_str(pInfo->manufacturerID, manufacturer_id, strlen(manufacturer_id), 32);
 
       pInfo->flags = CKF_TOKEN_PRESENT;
       pInfo->hardwareVersion = { 0, 0 };
@@ -233,14 +239,10 @@ C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 {
   return wrap_exceptions(__func__, [&]{
       // TODO: fill these out from token.
-      char label[] = "Simple-TPM-PK11 token";
-      char manuf_id[] = "manuf id";
-      char model[] = "model";
-      char serial[] = "serial";
-      write_pk11_str(pInfo->label, label, strlen(label), 32);
-      write_pk11_str(pInfo->manufacturerID, manuf_id, strlen(manuf_id), 32);
-      write_pk11_str(pInfo->model, model, strlen(model), 16);
-      write_pk11_str(pInfo->serialNumber, serial, strlen(serial), 16);
+      write_pk11_str(pInfo->label, token_label, strlen(token_label), 32);
+      write_pk11_str(pInfo->manufacturerID, manufacturer_id, strlen(manufacturer_id), 32);
+      write_pk11_str(pInfo->model, token_model, strlen(token_model), 16);
+      write_pk11_str(pInfo->serialNumber, token_serial, strlen(token_serial), 16);
 
       // TODO: Add CKF_RNG.
       pInfo->flags = CKF_TOKEN_INITIALIZED;

--- a/src/session.cc
+++ b/src/session.cc
@@ -510,6 +510,12 @@ void
 Session::Sign(CK_BYTE_PTR pData, CK_ULONG usDataLen,
               CK_BYTE_PTR pSignature, CK_ULONG_PTR pusSignatureLen)
 {
+  if (pSignature == nullptr) {
+    // when pSignature is NULL, we should tell caller the size of the buffer needed
+    // according to the call convention mentioned in the spec
+    *pusSignatureLen = 256; // signature size is 256 bytes
+    return;
+  }
   std::string kfs;
   try {
     kfs = stpm::slurp_file(config_.keyfile_);

--- a/src/session.h
+++ b/src/session.h
@@ -19,6 +19,7 @@
 #include<sstream>
 #include<stdexcept>
 #include<string>
+#include<vector>
 
 #include<opencryptoki/pkcs11.h>
 
@@ -54,6 +55,23 @@ public:
   void read_file(std::ifstream&);
 };
 
+/*
+typedef struct CK_ATTRIBUTE {
+  CK_ATTRIBUTE_TYPE type;
+  CK_VOID_PTR pValue;
+  CK_ULONG ulValueLen;
+} CK_ATTRIBUTE;
+*/
+
+// deep copy of CK_ATTRIBUTE
+// data_ is raw data (need to be reinterpret_cast to whatever makes sense)
+class CK_ATTRIBUTE_FULL {
+public:
+  CK_ATTRIBUTE_FULL(CK_ATTRIBUTE); // construct from CK_ATTRIBUTE
+  CK_ATTRIBUTE_TYPE type_;
+  std::vector<char> data_;
+};
+
 class Session {
 public:
   Session(const Config&);
@@ -77,8 +95,7 @@ private:
   // Set up by FindObjectsInit() used as state between FindObjects()
   // calls.
   int              findpos_ = 0;
-  CK_ATTRIBUTE_PTR find_filters_ = 0;
-  int              find_nfilters_ = 0;
+  std::vector<CK_ATTRIBUTE_FULL> find_filters_;
 };
 #endif
 /* ---- Emacs Variables ----


### PR DESCRIPTION
## Major Changes
- Implement CKA_LABEL, CKA_ID, and some other attributes on public key and private key objects.
- Fix string padding bugs (to comply with the standard)
- Fix segmentation faults when the caller passed null pointers to buffer. Passing null pointers is a defined behavior. The library should return the size of buffer needed.
- Make `FindObjects` more robust by deep copy the filter list in `FindObjectsInit`. This is not an issue for most pkcs11 clients written in C/C++. However, Golang based clients modify the memory used by the filter list between the call to `FindObjects` and `FindObjectsInit`.

## Motivation
I am planning to build a TLS CA on my home lab server (only has TPM 1.2 chip) and the CA software can take advantage of pkcs11 interface for additional security. This library doesn't work out of the box because many parts of the pkcs11 interface are not implemented. Now this library should play well with most pkcs11 clients. I have tested [pkcs11-tool (opensc)][opensc], [python-pkcs11][python-pkcs11], and [step-ca/kms][step-kms].

## (Arbitrary) Design Decisions
The label and ID of the keys are hardcoded strings (see commits). It doesn't really affect anything since those attributes are not used when searching for key objects.

## Unresolved Issues
Minor issue: When a private key no PIN is generated, the PIN (supplied by pkcs11 clients via `C_Login`) are ignored. Not sure this is the intended behavior.
Concurrency: there is no code dealing with concurrent access. Concurrent access behavior is untested.

## Future works (if someone have time...)
- Implement support for multiple keys
- Implement verification (this is not necessary but may be good to have)
- Implement key generation via pkcs11 interface


[opensc]: https://github.com/OpenSC/OpenSC/wiki
[python-pkcs11]: https://github.com/danni/python-pkcs11
[step-kms]: https://github.com/smallstep/step-kms-plugin